### PR TITLE
Use `crossbeam_channel` to remove mutex from `Mutex<Tracer>`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ default = [ "stacktrace" ]
 
 [dependencies]
 backtrace = { version = "0.3", optional = true }
+crossbeam-channel = "0.3"
 rand = "0.6"
 trackable = "0.2"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 // Creates a tracer
 let (span_tx, span_rx) = crossbeam_channel::bounded(10);
-let tracer = Tracer::new(AllSampler, span_tx);
+let tracer = Tracer::with_sender(AllSampler, span_tx);
 {
     // Starts "parent" span
     let parent_span = tracer.span("parent").start_with_state(());

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ use std::thread;
 use std::time::Duration;
 
 // Creates a tracer
-let (tracer, span_rx) = Tracer::new(AllSampler);
+let (span_tx, span_rx) = crossbeam_channel::bounded(10);
+let tracer = Tracer::new(AllSampler, span_tx);
 {
     // Starts "parent" span
     let parent_span = tracer.span("parent").start_with_state(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! // Creates a tracer
 //! let (span_tx, span_rx) = crossbeam_channel::bounded(10);
-//! let tracer = Tracer::new(AllSampler, span_tx);
+//! let tracer = Tracer::with_sender(AllSampler, span_tx);
 //! {
 //!     // Starts "parent" span
 //!     let parent_span = tracer.span("parent").start_with_state(());
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn it_works() {
         let (span_tx, span_rx) = crossbeam_channel::bounded(10);
-        let tracer = Tracer::new(AllSampler, span_tx);
+        let tracer = Tracer::with_sender(AllSampler, span_tx);
         {
             let span = tracer.span("it_works").start_with_state(());
             let mut child = span.child("child", |options| options.start_with_state(()));
@@ -96,7 +96,7 @@ mod tests {
     fn example_code_works() {
         // Creates a tracer
         let (span_tx, span_rx) = crossbeam_channel::bounded(10);
-        let tracer = Tracer::new(AllSampler, span_tx);
+        let tracer = Tracer::with_sender(AllSampler, span_tx);
         {
             // Starts "parent" span
             let parent_span = tracer.span("parent").start_with_state(());
@@ -127,7 +127,7 @@ mod tests {
     #[test]
     fn nonblocking_on_full_queue() {
         let (span_tx, span_rx) = crossbeam_channel::bounded(2);
-        let tracer = Tracer::new(AllSampler, span_tx);
+        let tracer = Tracer::with_sender(AllSampler, span_tx);
         {
             let span = tracer.span("first").start_with_state(());
             let mut child = span.child("second", |options| options.start_with_state(()));

--- a/src/span.rs
+++ b/src/span.rs
@@ -7,13 +7,12 @@ use crate::tag::{StdTag, Tag, TagValue};
 use crate::Result;
 use std::borrow::Cow;
 use std::io::{Read, Write};
-use std::sync::mpsc;
 use std::time::SystemTime;
 
 /// Finished span receiver.
-pub type SpanReceiver<T> = mpsc::Receiver<FinishedSpan<T>>;
-
-pub(crate) type SpanSender<T> = mpsc::Sender<FinishedSpan<T>>;
+pub type SpanReceiver<T> = crossbeam_channel::Receiver<FinishedSpan<T>>;
+/// Sender of finished spans to the destination channel.
+pub type SpanSender<T> = crossbeam_channel::Sender<FinishedSpan<T>>;
 
 /// Span.
 ///
@@ -214,7 +213,7 @@ impl<T> Drop for Span<T> {
                 logs: inner.logs,
                 context: inner.context,
             };
-            let _ = inner.span_tx.send(finished);
+            let _ = inner.span_tx.try_send(finished);
         }
     }
 }


### PR DESCRIPTION
- SIGNIFICANT API CHANGE!
- https://github.com/sile/rustracing_jaeger/blob/master/examples/http_hello_server.rs#L18
- Fighting for a mutex on hot path may be expensive in a service that handles thousands requests/s.
- The mutex was introduced due to `std::sync::mpsc` channel. Yes, it can be cloned and passed to multiple threads but its technically impossible in a HTTP service where the threads are out of application's full control. It would lead to tracer inside thread locals which would be also nothing good.
- It's also better to build the channel outside the tracer and only pass the sender part inside. The application may choose between bounded and unbounded, configure max. queue size, etc.