### PR TITLE
Allow resetting span start time

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -70,6 +70,16 @@ impl<T> Span<T> {
         }
     }
 
+    /// Sets the start time of this span.
+    pub fn set_start_time<F>(&mut self, f: F)
+    where
+        F: FnOnce() -> SystemTime,
+    {
+        if let Some(inner) = self.0.as_mut() {
+            inner.start_time = f();
+        }
+    }
+
     /// Sets the finish time of this span.
     pub fn set_finish_time<F>(&mut self, f: F)
     where


### PR DESCRIPTION
This is especially useful with futures when you can create a future and a span, but only want to start the span when future is first polled.