### PR TITLE
Add `SpanSend` trait to allow custom channels, and optional support of tokio's channel.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ default = [ "stacktrace" ]
 backtrace = { version = "0.3", optional = true }
 crossbeam-channel = "0.4"
 rand = "0.7"
+tokio = { version = "0.2", optional = true, features = ["sync"] }
 trackable = "0.2"

--- a/src/span.rs
+++ b/src/span.rs
@@ -717,3 +717,15 @@ impl<T> SpanSend<T> for tokio::sync::mpsc::Sender<FinishedSpan<T>> {
         let _ = self.try_send(span);
     }
 }
+
+#[cfg(all(test, feature = "tokio"))]
+mod tests {
+    use crate::sampler::AllSampler;
+    use crate::Tracer;
+
+    #[test]
+    fn tokio_channel() {
+        let (span_tx, _span_rx) = tokio::sync::mpsc::channel(10);
+        let _tracer = Tracer::<_, (), _>::with_sender(AllSampler, span_tx);
+    }
+}

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -1,6 +1,7 @@
 use crate::sampler::Sampler;
-use crate::span::{SpanReceiver, SpanSender, StartSpanOptions};
+use crate::span::{DefaultSpanReceiver, DefaultSpanSender, SpanSend, StartSpanOptions};
 use std::borrow::Cow;
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 /// Tracer.
@@ -20,50 +21,68 @@ use std::sync::Arc;
 /// assert_eq!(span.operation_name(), "foo");
 /// ```
 #[derive(Debug)]
-pub struct Tracer<S, T> {
+pub struct Tracer<S, T, Sender = DefaultSpanSender<T>> {
     sampler: Arc<S>,
-    span_tx: SpanSender<T>,
+    span_tx: Sender,
+    _span_state: PhantomData<T>,
 }
-impl<S: Sampler<T>, T> Tracer<S, T> {
+impl<S, T> Tracer<S, T, DefaultSpanSender<T>>
+where
+    S: Sampler<T>,
+{
     /// This constructor is mainly for backward compatibility, it has the same interface
     /// as in previous versions except the type of `SpanReceiver`.
     /// It builds an unbounded channel which may cause memory issues if there is no reader,
     /// prefer `with_sender()` alternative with a bounded one.
-    pub fn new(sampler: S) -> (Self, SpanReceiver<T>) {
+    pub fn new(sampler: S) -> (Self, DefaultSpanReceiver<T>) {
         let (span_tx, span_rx) = crossbeam_channel::unbounded();
         (Self::with_sender(sampler, span_tx), span_rx)
     }
-
+}
+impl<S, T, Sender> Tracer<S, T, Sender>
+where
+    S: Sampler<T>,
+    Sender: SpanSend<T>,
+{
     /// Makes a new `Tracer` instance.
-    pub fn with_sender(sampler: S, span_tx: SpanSender<T>) -> Self {
+    pub fn with_sender(sampler: S, span_tx: Sender) -> Self {
         Tracer {
             sampler: Arc::new(sampler),
             span_tx,
+            _span_state: PhantomData,
         }
     }
 
     /// Returns `StartSpanOptions` for starting a span which has the name `operation_name`.
-    pub fn span<N>(&self, operation_name: N) -> StartSpanOptions<S, T>
+    pub fn span<N>(&self, operation_name: N) -> StartSpanOptions<S, T, Sender>
     where
         N: Into<Cow<'static, str>>,
     {
         StartSpanOptions::new(operation_name, &self.span_tx, &self.sampler)
     }
 }
-impl<S, T> Tracer<S, T> {
+impl<S, T, Sender> Tracer<S, T, Sender>
+where
+    Sender: SpanSend<T>,
+{
     /// Clone with the given `sampler`.
-    pub fn clone_with_sampler<U: Sampler<T>>(&self, sampler: U) -> Tracer<U, T> {
+    pub fn clone_with_sampler<U: Sampler<T>>(&self, sampler: U) -> Tracer<U, T, Sender> {
         Tracer {
             sampler: Arc::new(sampler),
             span_tx: self.span_tx.clone(),
+            _span_state: PhantomData,
         }
     }
 }
-impl<S, T> Clone for Tracer<S, T> {
+impl<S, T, Sender> Clone for Tracer<S, T, Sender>
+where
+    Sender: SpanSend<T>,
+{
     fn clone(&self) -> Self {
         Tracer {
             sampler: Arc::clone(&self.sampler),
             span_tx: self.span_tx.clone(),
+            _span_state: PhantomData,
         }
     }
 }


### PR DESCRIPTION
This PR introduces `SpanSend` trait that allows users specifying custom channels other than the default crossbeam one.
Tokio's channel support is also added as an optional feature. You can create a tracer that uses tokio's channel as follows:
```rust
use rustracing::sampler::AllSampler;
use rustracing::Tracer;

let (span_tx, span_rx) = tokio::sync::mpsc::channel(10);
let tracer = Tracer::with_sender(AllSampler, span_tx);
```