### PR TITLE
Bump trackable from 0.2 to 1.2, fix clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ default = [ "stacktrace" ]
 backtrace = { version = "0.3", optional = true }
 crossbeam-channel = "0.5"
 rand = "0.8.1"
-trackable = "0.2"
+trackable = "1.2"

--- a/src/span.rs
+++ b/src/span.rs
@@ -162,7 +162,7 @@ impl<T> Span<T> {
             if let Some(log) = builder.finish() {
                 inner.logs.push(log);
             }
-            if inner.tags.iter().find(|x| x.name() == "error").is_none() {
+            if !inner.tags.iter().any(|x| x.name() == "error") {
                 inner.tags.push(StdTag::error());
             }
         }


### PR DESCRIPTION
Hi! I opened this PR because my project includes your project, which depends on the `trackable` lib. That lib has a newer version available, and other crates in my project use the newer version. So, I've opened this PR to update it. Now crates which use your project are less likely to compile two versions of `trackable`. I ran `cargo test --all-features`, but please let me know if there's anything else I can do to help test this.

If possible, I'd love for you to cut a patch release after merging this, so I can start using the new version and keep my project's compiletimes slim :)