### PR TITLE
Fix clippy errors

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -628,7 +628,7 @@ impl<T> SpanHandle<T> {
 
     /// Returns the context of this span.
     pub fn context(&self) -> Option<&SpanContext<T>> {
-        self.0.as_ref().map(|&(ref context, _)| context)
+        self.0.as_ref().map(|(context, _)| context)
     }
 
     /// Gets the baggage item that has the name `name`.
@@ -647,7 +647,7 @@ impl<T> SpanHandle<T> {
         T: Clone,
         F: FnOnce(StartSpanOptions<AllSampler, T>) -> Span<T>,
     {
-        if let Some(&(ref context, ref span_tx)) = self.0.as_ref() {
+        if let Some((context, span_tx)) = self.0.as_ref() {
             let options =
                 StartSpanOptions::new(operation_name, span_tx, &AllSampler).child_of(context);
             f(options)
@@ -663,7 +663,7 @@ impl<T> SpanHandle<T> {
         T: Clone,
         F: FnOnce(StartSpanOptions<AllSampler, T>) -> Span<T>,
     {
-        if let Some(&(ref context, ref span_tx)) = self.0.as_ref() {
+        if let Some((context, span_tx)) = self.0.as_ref() {
             let options =
                 StartSpanOptions::new(operation_name, span_tx, &AllSampler).follows_from(context);
             f(options)


### PR DESCRIPTION
Copilot Summary
-----------------

This pull request includes changes to the `SpanHandle` implementation in the `src/span.rs` file. The changes are primarily focused on simplifying the code by removing unnecessary references in the `context`, `start_child_span`, and `start_follows_from_span` methods.

Here are the key changes:

* [`src/span.rs`](diffhunk://#diff-b1d82de938c8711debfca1c4591654315b7c3ec75d1617f249e6baea94b1c2dbL631-R631): In the `SpanHandle` implementation, the `context` method was updated to remove the unnecessary reference in the `map` function. This simplifies the code and makes it more readable.
* [`src/span.rs`](diffhunk://#diff-b1d82de938c8711debfca1c4591654315b7c3ec75d1617f249e6baea94b1c2dbL650-R650): In the `SpanHandle` implementation, the `start_child_span` method was updated to remove the unnecessary references in the `if let` statement. This change simplifies the code and improves readability.
* [`src/span.rs`](diffhunk://#diff-b1d82de938c8711debfca1c4591654315b7c3ec75d1617f249e6baea94b1c2dbL666-R666): Similarly, in the `SpanHandle` implementation, the `start_follows_from_span` method was updated to remove the unnecessary references in the `if let` statement. This change also simplifies the code and improves readability.